### PR TITLE
Tencent GCC link modification

### DIFF
--- a/Company/Company-List.md
+++ b/Company/Company-List.md
@@ -54,7 +54,7 @@ SAP
 
 [Toyota](https://www.toyota.co.jp/jpn/sustainability/governance/compliance/Toyota_GPL_Commitment.pdf)
 
-[Tencent](https://github.com/gplcc/gplcc/blob/master/Company/Company-List.md)
+[Tencent](https://opensource.tencent.com/GPL-Cooperation-Commitment)
 
 [VMware](http://vmware.github.io/gpl-commitment)
 


### PR DESCRIPTION
The Tencent GCC link is wrong, change to the right link.