### PR TITLE
Updated Oath's name to Verizon Media

### DIFF
--- a/Company/Company-List.md
+++ b/Company/Company-List.md
@@ -60,7 +60,7 @@ NEC
 
 [NVIDIA](https://developer.nvidia.com/gpl-cooperation-commitment)
 
-[Oath](https://developer.yahoo.com/opensource/gplcc/)
+[Verizon Media](https://developer.yahoo.com/opensource/docs/GPL-Cooperation-Commitment.html)
 
 [Pivotal](https://content.pivotal.io/pivotal-blog/pivotal-joins-other-technology-industry-leaders-to-advance-open-source-licensing)
 


### PR DESCRIPTION
And I updated link to the new link on the Yahoo Developer Network. Note Verizon Media was called Oath and is composed mostly of Yahoo and AOL assets.