### PR TITLE
add Salesforce to the GPL Cooperation Commitment

### DIFF
--- a/Company/Company-List.md
+++ b/Company/Company-List.md
@@ -94,6 +94,8 @@ NEC
 
 Royal Philips
 
+[Salesforce](https://github.com/salesforce/gpl-commitment)
+
 SAP
 
 [SAS](https://support.sas.com/en/documentation/gpl-compliance-commitment.html)


### PR DESCRIPTION
Hi! I'd like to have Salesforce added to the GPL Cooperation Commitment.

I represent that I have the authority to make this request.

The company name is: Salesforce.com, Inc.

The URL to the company's GPL Cooperation Commitment is: https://github.com/salesforce/gpl-commitment