### PR TITLE
Update URL to GitLab GPL Commitment

### DIFF
--- a/Company/Company-List.md
+++ b/Company/Company-List.md
@@ -60,7 +60,7 @@ Facebook, Inc.
 
 [GitHub](https://help.github.com/articles/github-gpl-cooperation-commitment/)
 
-[GitLab](https://docs.gitlab.com/ee/development/licensing.html#gpl-cooperation-commitment)
+[GitLab](https://about.gitlab.com/handbook/legal/product/#gpl-cooperation-commitment)
 
 [Google LLC](https://opensource.google.com/gpl-enforcement/)
 


### PR DESCRIPTION
The URL to GitLab's GPL Commitment was changed. This PR updates the URL to https://about.gitlab.com/handbook/legal/product/#gpl-cooperation-commitment 

Creating this PR on behalf of GitLab, requested by our legal team. 